### PR TITLE
[17.0][FW] database_cleanup: multiple ports from 14.0

### DIFF
--- a/.oca/oca-port/blacklist/database_cleanup.json
+++ b/.oca/oca-port/blacklist/database_cleanup.json
@@ -1,0 +1,5 @@
+{
+  "pull_requests": {
+    "2523": "(auto) Nothing to port from PR #2523"
+  }
+}

--- a/database_cleanup/models/purge_columns.py
+++ b/database_cleanup/models/purge_columns.py
@@ -68,7 +68,8 @@ class CleanupPurgeWizardColumn(models.TransientModel):
     # Format: {table: [fields]}
     blacklist = {
         "wkf_instance": ["uid"],  # lp:1277899
-        "res_users": ["password", "password_crypt"],
+        "res_users": ["password", "password_crypt", "totp_secret"],
+        "res_partner": ["signup_token"],
     }
 
     @api.model

--- a/module_analysis/tests/module/views/assets.xml
+++ b/module_analysis/tests/module/views/assets.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo />


### PR DESCRIPTION
Port of the following PRs from 14.0 to 17.0:
- #2744
- #2993

The following PRs have been blacklisted:
- #2523: (auto) Nothing to port from PR #2523
